### PR TITLE
fix(styles): change container to only flex-grow

### DIFF
--- a/packages/mobile/components/Form/PhoneInput/styles.ts
+++ b/packages/mobile/components/Form/PhoneInput/styles.ts
@@ -6,7 +6,7 @@ interface PhoneInputContainerProps {
 }
 
 export const PhoneInputContainer = styled.View<PhoneInputContainerProps>`
-  flex: 1;
+  flex-grow: 1;
   height: 55px;
   align-items: center;
   border: 1px solid;


### PR DESCRIPTION
If we define the Input Container as flex: 1, the container of input is going to shrink in some cases, for example, in EditProfile at Levi. To prevent this component to shrink, we must set only flex-grow